### PR TITLE
Fix cp to be recursive

### DIFF
--- a/RICE/redhound/README.md
+++ b/RICE/redhound/README.md
@@ -28,7 +28,7 @@ Run the following commands in the terminal. This also creates a backup for any p
 
 ```
 git clone --depth 1 https://github.com/purhan/dotfiles.git
-cp ~/.config/awesome ~/.config/awesome_backup
+cp -r ~/.config/awesome ~/.config/awesome_backup
 mv -a dotfiles/RICE/redhound/. ~/.config/awesome
 rm -rf dotfiles
 ```


### PR DESCRIPTION
Hi, simple pr to fix the command typo in the readme. Without the `-r`, the config won't be backed up so this is a small but important error.